### PR TITLE
The mobile/components element was not there

### DIFF
--- a/app.json
+++ b/app.json
@@ -254,33 +254,34 @@
 				"measure_temperature",
 				"measure_battery"
 			],
-			"mobile": [
-				{
-					"id": "icon",
-					"capabilities": []
-				},
-				{
-					"id": "battery",
-					"capabilities": [
-						"measure_battery"
-					]
-				},
-				{
-					"id": "sensor",
-					"capabilities": [
-						"alarm_contact",
-						"alarm_motion",
-						"alarm_tamper",
-						"measure_luminance_level",
-						"measure_temperature"
-					],
-					"options": {
-						"icons": {
-							"measure_luminance_level": "./drivers/TSP01/assets/measure_luminance_level.svg"
+			"mobile": {
+				"components": [
+					{
+						"id": "icon"
+					},
+					{
+						"id": "battery",
+						"capabilities": [
+							"measure_battery"
+						]
+					},
+					{
+						"id": "sensor",
+						"capabilities": [
+							"alarm_contact",
+							"alarm_motion",
+							"alarm_tamper",
+							"measure_luminance_level",
+							"measure_temperature"
+						],
+						"options": {
+							"icons": {
+								"measure_luminance_level": "./drivers/TSP01/assets/measure_luminance_level.svg"
+							}
 						}
 					}
-				}
-			],
+				]
+			},
 			"images": {
 				"large": "/drivers/TSP01/assets/images/large.png",
 				"small": "/drivers/TSP01/assets/images/small.png"


### PR DESCRIPTION
hence a no_motion error when trying to display the values.

Another thing i'd like to give as feedback / proposal:
maybe it is a nice thing to change the order of the capabilities (in the mobile setting)?

So to start with the alarm_contact, then measure_luminance_level, then measure_temperature followed by alarm_contact and alarm_tamper.

This way you'll see the 3 items that are sent during a motion event (and has the most updates).